### PR TITLE
Fix min CEP prefix validation for SP

### DIFF
--- a/cep.go
+++ b/cep.go
@@ -22,11 +22,11 @@ func IsCEP(doc string, ufs ...FederativeUnit) bool {
 	h, _ := strconv.Atoi(doc[0:3])
 
 	if len(ufs) == 0 {
-		return h >= 010
+		return h >= 10
 	}
 
 	for _, uf := range ufs {
-		if (uf == SP && h >= 010 && h <= 199) ||
+		if (uf == SP && h >= 10 && h <= 199) ||
 			(uf == RJ && h >= 200 && h <= 289) ||
 			(uf == ES && h >= 290 && h <= 299) ||
 			(uf == MG && h >= 300 && h <= 399) ||

--- a/cep_test.go
+++ b/cep_test.go
@@ -48,6 +48,8 @@ func TestIsCEP(t *testing.T) {
 		{"InvalidFederativeUnit_ShouldReturnFalse", false, "89000-000", []FederativeUnit{RS}},
 		{"InvalidFederativeUnit_ShouldReturnFalse", false, "95000-000", []FederativeUnit{SP}},
 		{"InvalidFederativeUnit_ShouldReturnFalse", false, "29500-000", []FederativeUnit{MT, MS, MG}},
+		{"InvalidFederativeUnit_ShouldReturnFalse", false, "00801-000", []FederativeUnit{SP}},
+		{"InvalidFederativeUnit_ShouldReturnFalse", false, "00801-000", []FederativeUnit{}},
 		{"Valid_ShouldReturnTrue", true, "10000-000", []FederativeUnit{SP}},
 		{"Valid_ShouldReturnTrue", true, "25000-000", []FederativeUnit{RJ}},
 		{"Valid_ShouldReturnTrue", true, "29500-000", []FederativeUnit{ES}},


### PR DESCRIPTION
Primeiramente: adorei o pacote 🤩, obrigado por ter feito e por manter ele atualizado.

O prefixo mínimo de SP estava 010, que é 8 (já que 0 é prefixo de octal e 10 em octal é 8). Por conta disso, CEPs como "00801-000" eram dados como válidos indevidamente.

![image](https://user-images.githubusercontent.com/23013073/180589707-04ac5541-0728-41a7-a747-3e2291114a0d.png)

(código acima https://go.dev/play/p/2ehi9wo0H_T)

A correção consiste em usar 10 ao invés de 010. Também adicionei um teste validar para isso.