### PR TITLE
Add RG validation for SP and RJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ portuguese.
 
 BR Doc é um pacote para validação, tanto do formato quanto dos dígitos,
 de documentos brasileiros, como CPF, CNPJ, CEP, CNH, PIS/PASEP, RENAVAM, placa
-veicular e futuramente RG.
+veicular e RG no padrão SP e RJ (futuramente demais padrões).
 
 Aceito PRs de todas as formas. Está permitido escrever em português,
 também. :)
@@ -34,6 +34,7 @@ Principais funções:
 - `func IsNationalPlate(doc string) bool`
 - `func IsMercosulPlate(doc string) bool`
 - `func IsCNS(doc string) bool`
+- `func IsRG(doc string) bool`
 
 ## Coisas a fazer
 
@@ -44,7 +45,8 @@ Principais funções:
 - [x] validação de RENAVAM (obrigado @leogregianin!)
 - [x] validação de placa veicular
 - [x] validação de CNS (obrigado @renatosuero!)
-- [ ] validação de RG
+- [x] validação de RG padrão SP e RJ
+- [ ] validação de RG demais estados
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,10 @@ Principais funções:
 - [x] validação de RENAVAM (obrigado @leogregianin!)
 - [x] validação de placa veicular
 - [x] validação de CNS (obrigado @renatosuero!)
-- [x] validação de RG padrão SP e RJ
-- [ ] validação de RG demais estados
+- [ ] validação de RG
+  - [x] SP (obrigado @robas!)
+  - [x] RJ (obrigado @robas!)
+  - [ ] demais estados
 
 ## License
 

--- a/cep.go
+++ b/cep.go
@@ -63,37 +63,3 @@ func IsCEP(doc string, ufs ...FederativeUnit) bool {
 
 	return false
 }
-
-// FederativeUnit represents a state or a district in Brazil.
-type FederativeUnit uint8
-
-// Federative unit for CEP validation.
-const (
-	AC FederativeUnit = iota
-	AL
-	AP
-	AM
-	BA
-	CE
-	DF
-	ES
-	GO
-	MA
-	MT
-	MS
-	MG
-	PA
-	PB
-	PR
-	PE
-	PI
-	RJ
-	RN
-	RS
-	RO
-	RR
-	SC
-	SP
-	SE
-	TO
-)

--- a/rg.go
+++ b/rg.go
@@ -2,23 +2,38 @@ package brdoc
 
 import (
 	"bytes"
+	"errors"
 	"regexp"
 	"unicode"
 )
 
 var (
-	RGRegexp = regexp.MustCompile(`^\d{2}\.?\d{3}\.?\d{3}-?[0-9xX]$`)
+	rgRegexp = map[FederativeUnit]*regexp.Regexp{
+		SP: regexp.MustCompile(`^\d{2}\.?\d{3}\.?\d{3}-?[0-9xX]$`),
+		RJ: regexp.MustCompile(`^\d{2}\.?\d{3}\.?\d{3}-?[0-9xX]$`),
+	}
+	errNotImplementedUF = errors.New("federative unit not implemented")
 )
 
-func IsRG(doc string) bool {
-	if !RGRegexp.MatchString(doc) {
-		return false
+// IsRG verifies if `doc` is a valid RG.
+// `uf` represents the Federative Unit the RG belongs to.
+// Curently the only validation algorithm implemented works for the following Federative Units:
+//   - SP
+//   - RJ
+func IsRG(doc string, uf FederativeUnit) (isValid bool, err error) {
+	if uf != SP && uf != RJ {
+		return false, errNotImplementedUF
+	}
+
+	if !rgRegexp[uf].MatchString(doc) {
+		return false, nil
 	}
 
 	checkDigit := getRGCheckDigit(doc)
 	calculatedCheckDigit := calculateRGCheckDigit(doc)
 
-	return calculatedCheckDigit == checkDigit
+	return calculatedCheckDigit == checkDigit, nil
+
 }
 
 func calculateRGCheckDigit(doc string) int {

--- a/rg.go
+++ b/rg.go
@@ -17,7 +17,7 @@ var (
 
 // IsRG verifies if `doc` is a valid RG.
 // `uf` represents the Federative Unit the RG belongs to.
-// Curently the only validation algorithm implemented works for the following Federative Units:
+// Currently, the only implemented UFs are the following (the remaining will return an error):
 //   - SP
 //   - RJ
 func IsRG(doc string, uf FederativeUnit) (isValid bool, err error) {

--- a/rg.go
+++ b/rg.go
@@ -1,0 +1,61 @@
+package brdoc
+
+import (
+	"bytes"
+	"regexp"
+	"unicode"
+)
+
+var (
+	RGRegexp = regexp.MustCompile(`^\d{2}\.?\d{3}\.?\d{3}-?[0-9xX]$`)
+)
+
+func IsRG(doc string) bool {
+	if !RGRegexp.MatchString(doc) {
+		return false
+	}
+
+	checkDigit := getRGCheckDigit(doc)
+	calculatedCheckDigit := calculateRGCheckDigit(doc)
+
+	return calculatedCheckDigit == checkDigit
+}
+
+func calculateRGCheckDigit(doc string) int {
+	doc = cleanNonRGDigits(doc)
+	digitsSum := 0
+	for i, digit := range doc[:len(doc)-1] {
+		a := toInt(digit) * (i + 2)
+		digitsSum += a
+	}
+
+	return 11 - (digitsSum % 11)
+}
+
+func getRGCheckDigit(doc string) int {
+	switch lastDigit := rune(doc[len(doc)-1]); lastDigit {
+	case 'X', 'x':
+		return 10
+	case '0':
+		return 11
+	default:
+		return toInt(lastDigit)
+	}
+}
+
+// cleanNonDigits removes every rune that is not a valid RG digit.
+func cleanNonRGDigits(doc string) string {
+
+	buf := bytes.NewBufferString("")
+	for _, r := range doc {
+		if isRGValidDigit(r) {
+			buf.WriteRune(r)
+		}
+	}
+
+	return buf.String()
+}
+
+func isRGValidDigit(r rune) bool {
+	return unicode.IsDigit(r) || r == 'X' || r == 'x'
+}

--- a/rg_test.go
+++ b/rg_test.go
@@ -1,0 +1,127 @@
+package brdoc
+
+import (
+	"testing"
+)
+
+func TestIsRG(t *testing.T) {
+	for i, tc := range []struct {
+		name     string
+		expected bool
+		v        string
+	}{
+		{"InvalidData_ShouldReturnFalse", false, "3467875434578764345789654"},
+		{"InvalidData_ShouldReturnFalse", false, ""},
+		{"InvalidData_ShouldReturnFalse", false, "AAAAAAA"},
+		{"InvalidData_ShouldReturnFalse", false, "34.112.513-A"},
+		{"InvalidData_ShouldReturnFalse", false, "34.112.513-X"},
+		{"InvalidData_ShouldReturnFalse", false, "34.112.513-x"},
+		{"InvalidCheckDigit_ShouldReturnFalse", false, "34.112.513-9"},
+		{"ValidFormat_ShouldReturnTrue", true, "34.112.513-1"},
+		{"ValidFormat_ShouldReturnTrue", true, "341125131"},
+		{"ValidFormat_ShouldReturnTrue", true, "25.540.324-0"},
+		{"ValidFormat_ShouldReturnTrue", true, "255403240"},
+		{"ValidFormat_ShouldReturnTrue", true, "39.406.714-9"},
+		{"ValidFormat_ShouldReturnTrue", true, "24.454.119-X"},
+		{"ValidFormat_ShouldReturnTrue", true, "24454119X"},
+		{"ValidFormat_ShouldReturnTrue", true, "24.454.119-x"},
+		{"ValidFormat_ShouldReturnTrue", true, "24454119x"},
+		{"InvalidData_ShouldReturnFalse", false, "39.406.714-X"},
+		{"InvalidData_ShouldReturnFalse", false, "39.406.714-0"},
+	} {
+		t.Run(testName(i, tc.name), func(t *testing.T) {
+			assertEqual(t, tc.expected, IsRG(tc.v))
+		})
+	}
+}
+
+func TestCalculateRGCheckDigit(t *testing.T) {
+	for i, tc := range []struct {
+		name     string
+		expected int
+		v        string
+	}{
+		{"CalculateRGCheckDigit_ShouldReturn_1", 1, "34.112.513-1"},
+		{"CalculateRGCheckDigit_ShouldReturn_1", 1, "341125131"},
+		{"CalculateRGCheckDigit_ShouldReturn_9", 9, "39.406.714-9"},
+		{"CalculateRGCheckDigit_ShouldReturn_9", 9, "394067149"},
+		{"CalculateRGCheckDigit_ShouldReturn_11", 11, "25.540.324-0"},
+		{"CalculateRGCheckDigit_ShouldReturn_11", 11, "255403240"},
+		{"CalculateRGCheckDigit_ShouldReturn_10", 10, "24.454.119-X"},
+		{"CalculateRGCheckDigit_ShouldReturn_10", 10, "24454119X"},
+	} {
+		t.Run(testName(i, tc.name), func(t *testing.T) {
+			assertIntEqual(t, tc.expected, calculateRGCheckDigit(tc.v))
+		})
+	}
+}
+
+func TestGetRGCheckDigit(t *testing.T) {
+	for i, tc := range []struct {
+		name     string
+		expected int
+		v        string
+	}{
+		{"GetRGCheckDigit_ShouldReturn_1", 1, "34.112.513-1"},
+		{"GetRGCheckDigit_ShouldReturn_1", 1, "341125131"},
+		{"GetRGCheckDigit_ShouldReturn_9", 9, "39.406.714-9"},
+		{"GetRGCheckDigit_ShouldReturn_9", 9, "394067149"},
+		{"GetRGCheckDigit_ShouldReturn_11", 11, "25.540.324-0"},
+		{"GetRGCheckDigit_ShouldReturn_11", 11, "255403240"},
+		{"GetRGCheckDigit_ShouldReturn_10", 10, "24.454.119-X"},
+		{"GetRGCheckDigit_ShouldReturn_10", 10, "24454119X"},
+	} {
+		t.Run(testName(i, tc.name), func(t *testing.T) {
+			assertIntEqual(t, tc.expected, getRGCheckDigit(tc.v))
+		})
+	}
+}
+
+func TestCleanNonRGDigits(t *testing.T) {
+	for i, tc := range []struct {
+		name     string
+		expected string
+		v        string
+	}{
+		{"CleanNonRGDigits", "341125131", "34.112.513-1"},
+		{"CleanNonRGDigits", "341125131", "341125131"},
+		{"CleanNonRGDigits", "394067149", "39.406.714-9"},
+		{"CleanNonRGDigits", "394067149", "394067149"},
+		{"CleanNonRGDigits", "24454119X", "24.454.119-X"},
+		{"CleanNonRGDigits", "24454119X", "24454119X"},
+		{"CleanNonRGDigits", "24454119x", "24.454.119-x"},
+		{"CleanNonRGDigits", "24454119x", "24454119x"},
+		{"CleanNonRGDigits", "24454119x", "24//45///41--1.9x"},
+		{"CleanNonRGDigits", "", "AAaaaAAaaa"},
+		{"CleanNonRGDigits", "XxXxXx", "XxXxXx"},
+		{"CleanNonRGDigits", "XxXxXx", "XxXyxXx"},
+	} {
+		t.Run(testName(i, tc.name), func(t *testing.T) {
+			assertStringEqual(t, tc.expected, cleanNonRGDigits(tc.v))
+		})
+	}
+}
+
+func TestIsRGValidDigit(t *testing.T) {
+	for i, tc := range []struct {
+		name     string
+		expected bool
+		v        rune
+	}{
+		{"ValidDigit_ShouldReturnTrue", true, 'x'},
+		{"ValidDigit_ShouldReturnTrue", true, 'X'},
+		{"ValidDigit_ShouldReturnTrue", true, '1'},
+		{"ValidDigit_ShouldReturnTrue", true, '2'},
+		{"ValidDigit_ShouldReturnTrue", true, '3'},
+		{"ValidDigit_ShouldReturnTrue", true, '9'},
+		{"ValidDigit_ShouldReturnTrue", true, '0'},
+		{"InvalidDigit_ShouldReturnFalse", false, 'Y'},
+		{"InvalidDigit_ShouldReturnFalse", false, 'A'},
+		{"InvalidDigit_ShouldReturnFalse", false, '-'},
+		{"InvalidDigit_ShouldReturnFalse", false, '.'},
+	} {
+		t.Run(testName(i, tc.name), func(t *testing.T) {
+			assertEqual(t, tc.expected, isRGValidDigit(tc.v))
+		})
+	}
+}

--- a/rg_test.go
+++ b/rg_test.go
@@ -6,31 +6,44 @@ import (
 
 func TestIsRG(t *testing.T) {
 	for i, tc := range []struct {
-		name     string
-		expected bool
-		v        string
+		name            string
+		expectedIsValid bool
+		expectedErr     error
+		v               string
+		uf              FederativeUnit
 	}{
-		{"InvalidData_ShouldReturnFalse", false, "3467875434578764345789654"},
-		{"InvalidData_ShouldReturnFalse", false, ""},
-		{"InvalidData_ShouldReturnFalse", false, "AAAAAAA"},
-		{"InvalidData_ShouldReturnFalse", false, "34.112.513-A"},
-		{"InvalidData_ShouldReturnFalse", false, "34.112.513-X"},
-		{"InvalidData_ShouldReturnFalse", false, "34.112.513-x"},
-		{"InvalidCheckDigit_ShouldReturnFalse", false, "34.112.513-9"},
-		{"ValidFormat_ShouldReturnTrue", true, "34.112.513-1"},
-		{"ValidFormat_ShouldReturnTrue", true, "341125131"},
-		{"ValidFormat_ShouldReturnTrue", true, "25.540.324-0"},
-		{"ValidFormat_ShouldReturnTrue", true, "255403240"},
-		{"ValidFormat_ShouldReturnTrue", true, "39.406.714-9"},
-		{"ValidFormat_ShouldReturnTrue", true, "24.454.119-X"},
-		{"ValidFormat_ShouldReturnTrue", true, "24454119X"},
-		{"ValidFormat_ShouldReturnTrue", true, "24.454.119-x"},
-		{"ValidFormat_ShouldReturnTrue", true, "24454119x"},
-		{"InvalidData_ShouldReturnFalse", false, "39.406.714-X"},
-		{"InvalidData_ShouldReturnFalse", false, "39.406.714-0"},
+		{"InvalidData_ShouldReturnFalse", false, nil, "3467875434578764345789654", SP},
+		{"InvalidData_ShouldReturnFalse", false, nil, "", SP},
+		{"InvalidData_ShouldReturnFalse", false, nil, "AAAAAAA", SP},
+		{"InvalidData_ShouldReturnFalse", false, nil, "34.112.513-A", SP},
+		{"InvalidData_ShouldReturnFalse", false, nil, "34.112.513-X", SP},
+		{"InvalidData_ShouldReturnFalse", false, nil, "34.112.513-x", SP},
+		{"InvalidCheckDigit_ShouldReturnFalse", false, nil, "34.112.513-9", SP},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "34.112.513-1", SP},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "341125131", SP},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "25.540.324-0", RJ},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "255403240", RJ},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "39.406.714-9", RJ},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "24.454.119-X", RJ},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "24454119X", RJ},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "24.454.119-x", RJ},
+		{"ValidFormat_ShouldReturnTrue", true, nil, "24454119x", RJ},
+		{"InvalidData_ShouldReturnFalse", false, nil, "39.406.714-X", RJ},
+		{"InvalidData_ShouldReturnFalse", false, nil, "39.406.714-0", RJ},
+		{"InvalidData_ShouldReturnFalse", false, errNotImplementedUF, "39.406.714-0", PR},
+		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "25.540.324-0", ES},
+		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "255403240", BA},
+		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "39.406.714-9", MT},
+		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "24.454.119-X", RS},
+		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "24.454.119-X", RS},
+		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "24454119X", DF},
 	} {
 		t.Run(testName(i, tc.name), func(t *testing.T) {
-			assertEqual(t, tc.expected, IsRG(tc.v))
+			isValid, err := IsRG(tc.v, tc.uf)
+			assertEqual(t, tc.expectedErr, err)
+			if err == nil {
+				assertEqual(t, tc.expectedIsValid, isValid)
+			}
 		})
 	}
 }
@@ -51,7 +64,7 @@ func TestCalculateRGCheckDigit(t *testing.T) {
 		{"CalculateRGCheckDigit_ShouldReturn_10", 10, "24454119X"},
 	} {
 		t.Run(testName(i, tc.name), func(t *testing.T) {
-			assertIntEqual(t, tc.expected, calculateRGCheckDigit(tc.v))
+			assertEqual(t, tc.expected, calculateRGCheckDigit(tc.v))
 		})
 	}
 }
@@ -72,7 +85,7 @@ func TestGetRGCheckDigit(t *testing.T) {
 		{"GetRGCheckDigit_ShouldReturn_10", 10, "24454119X"},
 	} {
 		t.Run(testName(i, tc.name), func(t *testing.T) {
-			assertIntEqual(t, tc.expected, getRGCheckDigit(tc.v))
+			assertEqual(t, tc.expected, getRGCheckDigit(tc.v))
 		})
 	}
 }
@@ -97,7 +110,7 @@ func TestCleanNonRGDigits(t *testing.T) {
 		{"CleanNonRGDigits", "XxXxXx", "XxXyxXx"},
 	} {
 		t.Run(testName(i, tc.name), func(t *testing.T) {
-			assertStringEqual(t, tc.expected, cleanNonRGDigits(tc.v))
+			assertEqual(t, tc.expected, cleanNonRGDigits(tc.v))
 		})
 	}
 }

--- a/rg_test.go
+++ b/rg_test.go
@@ -30,13 +30,13 @@ func TestIsRG(t *testing.T) {
 		{"ValidFormat_ShouldReturnTrue", true, nil, "24454119x", RJ},
 		{"InvalidData_ShouldReturnFalse", false, nil, "39.406.714-X", RJ},
 		{"InvalidData_ShouldReturnFalse", false, nil, "39.406.714-0", RJ},
-		{"InvalidData_ShouldReturnFalse", false, errNotImplementedUF, "39.406.714-0", PR},
-		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "25.540.324-0", ES},
-		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "255403240", BA},
-		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "39.406.714-9", MT},
-		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "24.454.119-X", RS},
-		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "24.454.119-X", RS},
-		{"ValidFormat_ShouldReturnTrue", false, errNotImplementedUF, "24454119X", DF},
+		{"NotImplementedUF_ShouldReturnError", false, errNotImplementedUF, "39.406.714-0", PR},
+		{"NotImplementedUF_ShouldReturnError", false, errNotImplementedUF, "25.540.324-0", ES},
+		{"NotImplementedUF_ShouldReturnError", false, errNotImplementedUF, "255403240", BA},
+		{"NotImplementedUF_ShouldReturnError", false, errNotImplementedUF, "39.406.714-9", MT},
+		{"NotImplementedUF_ShouldReturnError", false, errNotImplementedUF, "24.454.119-X", RS},
+		{"NotImplementedUF_ShouldReturnError", false, errNotImplementedUF, "24.454.119-X", RS},
+		{"NotImplementedUF_ShouldReturnError", false, errNotImplementedUF, "24454119X", DF},
 	} {
 		t.Run(testName(i, tc.name), func(t *testing.T) {
 			isValid, err := IsRG(tc.v, tc.uf)

--- a/uf.go
+++ b/uf.go
@@ -1,0 +1,35 @@
+package brdoc
+
+// FederativeUnit represents a state or a district in Brazil.
+type FederativeUnit uint8
+
+// Federative unit for CEP validation.
+const (
+	AC FederativeUnit = iota
+	AL
+	AP
+	AM
+	BA
+	CE
+	DF
+	ES
+	GO
+	MA
+	MT
+	MS
+	MG
+	PA
+	PB
+	PR
+	PE
+	PI
+	RJ
+	RN
+	RS
+	RO
+	RR
+	SC
+	SP
+	SE
+	TO
+)

--- a/utils_test.go
+++ b/utils_test.go
@@ -15,6 +15,26 @@ actual:   %v
 	}
 }
 
+func assertIntEqual(t *testing.T, expected, actual int) {
+	if expected != actual {
+		t.Fatalf(`
+Not equal!
+expected: %v
+actual:   %v
+`, expected, actual)
+	}
+}
+
+func assertStringEqual(t *testing.T, expected, actual string) {
+	if expected != actual {
+		t.Fatalf(`
+Not equal!
+expected: %v
+actual:   %v
+`, expected, actual)
+	}
+}
+
 func testName(i int, name string) string {
 	return fmt.Sprintf("%d_%s", i, name)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -5,27 +5,7 @@ import (
 	"testing"
 )
 
-func assertEqual(t *testing.T, expected, actual bool) {
-	if expected != actual {
-		t.Fatalf(`
-Not equal!
-expected: %v
-actual:   %v
-`, expected, actual)
-	}
-}
-
-func assertIntEqual(t *testing.T, expected, actual int) {
-	if expected != actual {
-		t.Fatalf(`
-Not equal!
-expected: %v
-actual:   %v
-`, expected, actual)
-	}
-}
-
-func assertStringEqual(t *testing.T, expected, actual string) {
+func assertEqual(t *testing.T, expected, actual interface{}) {
 	if expected != actual {
 		t.Fatalf(`
 Not equal!


### PR DESCRIPTION
Add RG validation for SP and RJ, and 2 new assert methods on `utils_test.go` to handle string and int comparison.
Also update the TODO section in README.